### PR TITLE
Improve CI 

### DIFF
--- a/.github/workflows/ci-convert.yml
+++ b/.github/workflows/ci-convert.yml
@@ -1,16 +1,20 @@
 # This workflow is used to convert changed HTAN.model.csv to HTAN.model.jsonld
 # and push the updated HTAN.model.jsonld to feature branch
 
-name: Schema Converter
+name: CI
 
 on:
-  push:
-    paths:
-      - 'HTAN.model.csv'
+  pull_request:
+    branches: main
+    paths: 'HTAN.model.csv'
 
 jobs:
-  build:
+  CI:
+    name: schema-convert
     runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
     steps:
       - uses: actions/checkout@v2
       - name: Install System Dependencies
@@ -32,11 +36,17 @@ jobs:
         run: |
           schematic schema convert HTAN.model.csv
 
-      - name: Update .jsonld in the Branch
+      - uses: r-lib/actions/pr-fetch@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Commit the changes
         run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-          git checkout ${GITHUB_REF##*/}
+          git config --local user.name "$GITHUB_ACTOR"
+          git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
           git add HTAN.model.jsonld
-          git commit -m "auto convert to .jsonld"
-          git push origin ${GITHUB_REF##*/}
+          git commit -m "GitHub Action: convert *.model.csv to *.model.jsonld" || echo "No changes to commit"
+
+      - uses: r-lib/actions/pr-push@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
For auto converter CI, I noticed some bugs:
1. Currently, it will also run if pushing to main. The CI should only run when PR is created against main, so that contributors can view the changes of auto converted jsonld. If CI passes and changes looks good, there is no need to convert again after merging. I also added a protection rule to require check passed before merging.
<img width="783" alt="Screen Shot 2022-05-19 at 8 41 42 AM" src="https://user-images.githubusercontent.com/73901500/169295981-8fbd59ca-46b1-473a-8038-13cac30bd63d.png">

2. If PR has initially changed the csv file, but the continuous commits in the PR does not make changes on csv file,  the below error will occur: - to solve this, simply add echo message if no changes occur.
```
nothing added to commit but untracked files present (use "git add" to track)
```
3. I also added to fetch the branch before committing to avoid errors.