### PR TITLE
Add not planned action

### DIFF
--- a/.github/workflows/notplanned.yml
+++ b/.github/workflows/notplanned.yml
@@ -1,0 +1,13 @@
+on:
+  issues:
+    types: [labeled]
+jobs:
+  Move_Labeled_Issue_On_Project_Board:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: konradpabjan/move-labeled-or-milestoned-issue@v2.0
+      with:
+        action-token: "${{ secrets.ADD_TO_PROJECT_PAT }}"
+        project-url: "https://github.com/orgs/github/projects/4"
+        column-name: "Not planned"
+        label-name: "notplanned"


### PR DESCRIPTION
Adds an action so that when the label `notplanned` is applied the issue is moved to the `Not planned` column of the Data Model project.

Fixes #140 

Uses this action from the marketplace: https://github.com/marketplace/actions/move-labeled-or-milestoned-issue-to-a-specific-project-column