### PR TITLE
Update ci-lint-validate-convert.yml to actions/checkout@v3

### DIFF
--- a/.github/workflows/ci-lint-validate-convert.yml
+++ b/.github/workflows/ci-lint-validate-convert.yml
@@ -24,7 +24,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-python@v4 
         with:
           python-version: '3.10'
@@ -60,7 +60,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-python@v4 
         with:
           python-version: '3.9'


### PR DESCRIPTION
Updates actions/checkout to actions/checkout@v3 which includes Node.js 16 as Node.js 12 used in actions/checkout@v2 is deprecated