### PR TITLE
Remove ImagingLevel3Image and ImagingLevel3Channels

### DIFF
--- a/dca-template-config.json
+++ b/dca-template-config.json
@@ -136,11 +136,6 @@
         "type": "file"
       },
       {
-        "display_name": "Imaging Level 3 Image",
-        "schema_name": "ImagingLevel3Image",
-        "type": "file"
-      },
-      {
         "display_name": "Imaging Level 3 Segmentation",
         "schema_name": "ImagingLevel3Segmentation",
         "type": "file"
@@ -368,11 +363,6 @@
       {
         "display_name": "Follow Up",
         "schema_name": "FollowUp",
-        "type": "record"
-      },
-      {
-        "display_name": "Imaging Level 3 Channels",
-        "schema_name": "ImagingLevel3Channels",
         "type": "record"
       },
       {


### PR DESCRIPTION
These have been causing confusion [per Slack](https://htanworkspace.slack.com/archives/C03E345AMLK/p1737995628461699), as they were implemented in our data model but never used by other centers. In final Phase 1 push it is confusing to centers to have them avaliable for use when we would prefer not to at this late stage. This PR removes them from the display config.

This change requires propagation to [the config file ](https://github.com/Sage-Bionetworks/data_curator_config/blob/prod/HTAN/dca_config.json) to be implemented