### PR TITLE
fix: add PR context check to prevent undefined ref error

### DIFF
--- a/.github/workflows/ci-lint-validate-convert.yml
+++ b/.github/workflows/ci-lint-validate-convert.yml
@@ -86,7 +86,18 @@ jobs:
         run: |
           schematic schema convert HTAN.model.csv
 
-      - uses: r-lib/actions/pr-fetch@v2
+      - name: Check if in PR context
+        id: check_pr
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "is_pr=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_pr=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Fetch PR context
+        if: steps.check_pr.outputs.is_pr == 'true'
+        uses: r-lib/actions/pr-fetch@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -95,7 +106,9 @@ jobs:
           git add HTAN.model.jsonld
           git commit -m "GitHub Action: convert *.model.csv to *.model.jsonld" || echo "No changes to commit"
 
-      - uses: r-lib/actions/pr-push@v2
+      - name: Push changes
+        if: steps.check_pr.outputs.is_pr == 'true'
+        uses: r-lib/actions/pr-push@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Description
This PR fixes an issue in the JSON-LD conversion workflow where the action was failing with the error "Cannot read properties of undefined (reading 'ref')" when triggered manually or by a release event.

### Changes
- Added a PR context check to conditionally run PR-related steps
- The workflow now only attempts to fetch and push PR changes when triggered by a pull request
- Manual triggers and release events will skip the PR-related steps while still performing the JSON-LD conversion

### Testing
- Successfully tested the workflow with a manual trigger on this branch
- The JSON-LD conversion completes without errors
- PR-related steps are properly skipped when not in a PR context