### PR TITLE
fix: update workflow to handle both PR and non-PR contexts for JSONLD conversion

### DIFF
--- a/.github/workflows/ci-lint-validate-convert.yml
+++ b/.github/workflows/ci-lint-validate-convert.yml
@@ -101,16 +101,26 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Configure Git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
       - name: Commit the changes
         run: |
           git add HTAN.model.jsonld
           git commit -m "GitHub Action: convert *.model.csv to *.model.jsonld" || echo "No changes to commit"
 
-      - name: Push changes
+      - name: Push changes in PR context
         if: steps.check_pr.outputs.is_pr == 'true'
         uses: r-lib/actions/pr-push@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push changes in non-PR context
+        if: steps.check_pr.outputs.is_pr == 'false'
+        run: |
+          git push origin HEAD:${{ github.ref_name }}
 
   build-dependencies:
     name: Build Dependencies Table


### PR DESCRIPTION
## Description
This PR fixes an issue where the JSON-LD file wasn't being updated when the workflow runs on the main branch. The workflow was only pushing changes in PR contexts, but not when running directly on main.

### Changes
- Added Git configuration step to set up the bot's identity
- Split the push step into two separate steps:
  - One for PR context (using `pr-push`)
  - One for non-PR context (using direct `git push`)
- Added proper handling for both PR and non-PR contexts

### Testing
- Successfully tested the workflow with a manual trigger
- Verified that changes are committed and pushed in both PR and non-PR contexts

Fixes #509 